### PR TITLE
Add rule removing trigger label

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -22,3 +22,12 @@ pull_request_rules:
         strict: smart
         strict_method: rebase
         priority: medium
+
+  - name: remove on-merge-queue label after failure
+    conditions:
+      - "check-success!=ci/circleci: build-and-test"
+      - base=main
+      - label=on-merge-queue
+    actions:
+      label:
+        remove: [on-merge-queue]


### PR DESCRIPTION
This commit updates the mergify configuration to remove the "on-merge-queue" label when pull-requests fail tests. This configuration pattern serves the purpose of preventing updates to failing PRs from accidentally being merged.